### PR TITLE
add utc to solar hour and tests

### DIFF
--- a/src/thermohl/sun.py
+++ b/src/thermohl/sun.py
@@ -16,6 +16,35 @@ import numpy as np
 from thermohl import floatArrayLike, intArrayLike
 
 
+
+def utc2solar_hour(hour, minute=0., second=0., lon=0.):
+    """convert utc hour to solar hour adding the longitude contribution
+
+    If more than one input are numpy arrays, they should have the same size.
+
+    Parameters
+    ----------
+    hour : float or numpy.ndarray
+        Hour of the day (solar, must be between 0 and 23).
+    minute : float or numpy.ndarray, optional
+        Minutes on the clock. The default is 0.
+    second : float or numpy.ndarray, optional
+        Seconds on the clock. The default is 0.
+    lon : float or numpy.ndarray, optional
+        Longitude (in rad). The default is 0.
+
+    Returns
+    -------
+    float or numpy.ndarray
+        solar hour
+
+    """
+    # add 4 min (1/15 of an hour) for every degree of east longitude
+    solar_hour = hour % 24 + minute / 60. + second / 3600. + np.rad2deg(lon) / 15.
+    return solar_hour
+
+
+
 def hour_angle(
     hour: floatArrayLike, minute: floatArrayLike = 0.0, second: floatArrayLike = 0.0
 ) -> floatArrayLike:

--- a/test/unit/test_sun.py
+++ b/test/unit/test_sun.py
@@ -1,0 +1,63 @@
+import numpy as np
+from thermohl.sun import utc2solar_hour
+
+
+def test_scalar_input():
+    # Test with scalar inputs
+    hour = 12
+    minute = 30
+    second = 45
+    lon = np.deg2rad(45)  # 45 degrees east
+
+    result = utc2solar_hour(hour, minute, second, lon)
+    expected_result = 12 + 30 / 60. + 45 / 3600. + 45 / 15.
+    assert np.isclose(result, expected_result)
+
+def test_array_input():
+    # Test with numpy array inputs
+    hours = np.array([12, 15, 18])
+    minutes = np.array([30, 45, 0])
+    seconds = np.array([45, 30, 15])
+    lons = np.deg2rad(np.array([45, 90, 135]))  # 45, 90, and 135 degrees east
+
+    result = utc2solar_hour(hours, minutes, seconds, lons)
+    expected_result = np.array([
+        12 + 30 / 60. + 45 / 3600. + 45 / 15.,
+        15 + 45 / 60. + 30 / 3600. + 90 / 15.,
+        18 + 0 / 60. + 15 / 3600. + 135 / 15.
+    ])
+    np.testing.assert_array_almost_equal(result, expected_result)
+
+def test_edge_cases():
+    # Test edge cases
+    hour = 23
+    minute = 59
+    second = 59
+    lon = np.deg2rad(180)  # 180 degrees east
+
+    result = utc2solar_hour(hour, minute, second, lon)
+    expected_result = 23 + 59 / 60. + 59 / 3600. + 180 / 15.
+    assert np.isclose(result, expected_result)
+
+    hour = 0
+    minute = 0
+    second = 0
+    lon = np.deg2rad(-180)  # 180 degrees west
+
+    result = utc2solar_hour(hour, minute, second, lon)
+    expected_result = 0 + 0 / 60. + 0 / 3600. - 180 / 15.
+    assert np.isclose(result, expected_result)
+
+def test_realistic_cases():
+    # Test edge cases
+    hour = 23 * np.ones(3)
+    minute = 59 * np.ones(3)
+    second = 59 * np.ones(3)
+    lon = np.deg2rad(np.array([2.33472, 7.75, -4.48]))  # Paris, Strasbourg, Brest
+
+    result = utc2solar_hour(hour, minute, second, lon)
+    expected_result = 23 + 59 / 60. + 59 / 3600.
+    
+    assert result[0] > expected_result
+    assert result[1] > result[0]
+    assert result[2] < expected_result


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
The solar hour seems to not take into account longitude. The user appears to calculate the solar time independently, which may lead to confusion with utc.


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Add a converter utc to solar hour.

For the moment :
- No documentation 
- no integration (function is provided as a helper
- possible side effect with date (possibly not if only hour is needed)


**What is the current behavior?**
<!-- You can also link to an open issue here -->



**What is the new behavior (if this is a feature change)?**



**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [ X] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [ ] The *breaking change* or *deprecated* label has been added
- [ ] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->
--


**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
