### PR TITLE
feat(57): Make Scipy optional

### DIFF
--- a/.github/workflows/build-project.yml
+++ b/.github/workflows/build-project.yml
@@ -52,7 +52,8 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install -e .[dev]
+        pip install .
+        pip install --group test
 
     - name: Run tests on ${{ matrix.os }} with Python ${{ matrix.python-version }}
       run: pytest
@@ -79,7 +80,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install --upgrade build
-          pip install -e .[dev]
+          pip install .
 
       - name: Build
         run: |

--- a/.github/workflows/cd-pypi.yml
+++ b/.github/workflows/cd-pypi.yml
@@ -36,7 +36,8 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install --upgrade build
-          pip install -e .[dev]
+          pip install .
+          pip install --group test
 
       - name: ✔️ Run tests and generate coverage report
         run: |

--- a/.github/workflows/cd-test-pypi.yml
+++ b/.github/workflows/cd-test-pypi.yml
@@ -37,7 +37,8 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install --upgrade build
-          pip install -e .[dev]
+          pip install .
+          pip install --group test
 
       - name: ✔️ Run tests and generate coverage report
         run: |

--- a/.github/workflows/sonarcloud-analysis.yml
+++ b/.github/workflows/sonarcloud-analysis.yml
@@ -69,7 +69,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install .
-          pip install -e .[test]
+          pip install --group test
 
       - name: Run tests and generate coverage report
         run: |

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -11,13 +11,11 @@ build:
   os: "ubuntu-24.04"
   tools:
     python: "3.11"
-
-python:
-  install:
-    - method: pip
-      path: .
-      extra_requirements:
-        - docs
+  jobs:
+    install:
+      - pip install --upgrade pip
+      - pip install .
+      - pip install --group docs
 
 mkdocs:
   configuration: thermohl-docs/mkdocs.yml

--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@ SPDX-License-Identifier: MPL-2.0
 [![Lines of Code](https://sonarcloud.io/api/project_badges/measure?project=phlowers_thermohl&metric=ncloc)](https://sonarcloud.io/summary/new_code?id=phlowers_thermohl)
 [![Coverage](https://sonarcloud.io/api/project_badges/measure?project=phlowers_thermohl&metric=coverage)](https://sonarcloud.io/summary/new_code?id=phlowers_thermohl)
 
-# ThermOHL
+[![pyodide](https://img.shields.io/badge/works_on-pyodide-%237303fc)](https://pyodide.org/en/stable/index.html)
+
 
 Temperature estimation of overhead line conductors is an important topic for 
 TSOs for technical, economic, and safety-related reasons (DLR/ampacity, sag 
@@ -60,22 +61,37 @@ the power terms used, and default values are provided.
   https://doi.org/10.1109/IEEESTD.2013.6692858.
 
 
-## Installation
+## Users
 
-### Using pip
+---
+
+### Environment
+ThermOHL is using pip for project and dependencies management.
+You need a compatible version of python (3.8 or higher). You may have to install it manually (e.g. with pyenv). Then you may create a virtualenv and activate it.
+
+### Set up thermohl
 
 To install the package using pip, execute the following command:
 
 ```shell
-    python -m pip install thermohl@git+https://github.com/phlowers/thermohl
+    pip install thermohl
 ```
 
-## Development
+Use it ! You can report to the user guide section.
+```shell
+    import thermohl
+    print(thermohl.__version__)
+```
+
+## Developers
+
+---
 
 Install the development dependencies and program scripts via
 
 ```shell
-  pip install -e .[dev]
+  pip install -e .
+  pip install --group dev
 ```
 
 Build a new wheel via
@@ -94,7 +110,7 @@ First, make sure you have mkdocs and the Readthedocs theme installed.
 If you use pip, open a terminal and enter the following commands:
 
 ```shell 
-  pip install -e .[docs]
+  pip install --group docs
 ```
 
 Then, in the same terminal, build the doc with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "thermohl"
-version = "1.3.2"
+version = "1.3.2-rc0"
 
 description = "Calculations relative to temperature and ampacity in overhead conductors."
 license = "MPL-2.0"
@@ -35,11 +35,10 @@ classifiers = [
 dependencies = [
     "numpy >= 1.26.0",
     "pandas >= 2.1.2",
-    "scipy >= 1.13.1",
     "pyyaml >= 6.0.1"
 ]
 
-[project.optional-dependencies]
+[dependency-groups]
 test = [
     "pytest >= 7.2.2",
     "pytest-cov >= 6.0.0",
@@ -51,7 +50,8 @@ lint = [
     "ruff >= 0.8.0"
 ]
 dev = [
-    "thermohl[test,lint]",
+    { include-group = 'test' },
+    { include-group = 'lint' }
 ]
 docs = [
     "mkdocs >= 1.6.1",
@@ -62,7 +62,12 @@ docs = [
     "markdown_extensions >= 0.0.1",
     "markdown-include >= 0.8.1",
     "mkdocs-markdownextradata-plugin >= 0.2.6",
-    "thermohl[lint]",
+    { include-group = 'lint' },
+]
+
+[project.optional-dependencies]
+scientific = [
+    "scipy >= 1.13.1",
 ]
 
 [project.urls]

--- a/src/thermohl/__init__.py
+++ b/src/thermohl/__init__.py
@@ -5,13 +5,13 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # SPDX-License-Identifier: MPL-2.0
 
+from importlib.metadata import version
 from typing import Union, List
 
 import numpy as np
 import numpy.typing as npt
-import scipy
 
-frozen_dist = scipy.stats._distn_infrastructure.rv_continuous_frozen
+__version__ = version("thermohl")
 
 floatArrayLike = Union[float, npt.NDArray[np.float64]]
 intArrayLike = Union[int, npt.NDArray[np.int64]]

--- a/src/thermohl/distributions.py
+++ b/src/thermohl/distributions.py
@@ -11,12 +11,23 @@ import warnings
 from typing import Union, Optional
 
 import numpy as np
-import scipy
-from scipy.special import erf
-from scipy.special import i0
-from scipy.special import i1
 
-from thermohl import floatArrayLike, frozen_dist
+from thermohl.utils import depends_on_optional
+
+try:
+    import scipy
+    from scipy.special import erf, i0, i1
+    from scipy.stats._distn_infrastructure import rv_continuous_frozen as frozen_dist
+except ImportError:
+    warnings.warn(
+        "scipy is not installed. Some functions will not be available.",
+        RuntimeWarning,
+    )
+    frozen_dist = object
+
+
+
+from thermohl import floatArrayLike
 
 _twopi = 2 * np.pi
 
@@ -26,6 +37,7 @@ def _phi(x: float) -> float:
     return np.exp(-0.5 * x**2) / np.sqrt(_twopi)
 
 
+@depends_on_optional("scipy")
 def _psi(x: float) -> float:
     """CDF of standard normal distribution."""
     return 0.5 * (1 + erf(x / np.sqrt(2)))
@@ -55,6 +67,7 @@ def _truncnorm_mean_std(
     return mean, std
 
 
+@depends_on_optional("scipy")
 def truncnorm(
     a: float,
     b: float,
@@ -101,6 +114,7 @@ def truncnorm(
     return dist
 
 
+@depends_on_optional("scipy")
 class WrappedNormal(object):
     """Wrapped-Normal distribution. Not as complete as a scipy.stat distribution."""
 
@@ -117,6 +131,7 @@ class WrappedNormal(object):
         self.sigma = sigma
         return
 
+    @depends_on_optional("scipy")
     def rvs(
         self,
         size: int = 1,
@@ -167,11 +182,13 @@ def wrapnorm(mu: float, sigma: float) -> WrappedNormal:
     return WrappedNormal(mu2, sigma)
 
 
+@depends_on_optional("scipy")
 def _vonmises_circ_var(kappa: float) -> float:
     """Von Mises distribution circular variance."""
     return 1 - i1(kappa) / i0(kappa)
 
 
+@depends_on_optional("scipy")
 def _vonmises_kappa(sigma: float) -> float:
     """Get von Mises parameter that matches std in input."""
     from scipy.optimize import newton
@@ -190,6 +207,7 @@ def _vonmises_kappa(sigma: float) -> float:
     return kappa
 
 
+@depends_on_optional("scipy")
 def vonmises(mu: float, sigma: float) -> frozen_dist:
     """Get von Mises distribution.
     -- in radians, in [-pi,+pi]

--- a/src/thermohl/utils.py
+++ b/src/thermohl/utils.py
@@ -10,6 +10,8 @@
 """Misc. utility code for thermohl project."""
 
 import os
+from functools import wraps
+from importlib.util import find_spec
 
 import numpy as np
 import pandas as pd
@@ -240,3 +242,19 @@ def quasi_newton_2d(
             break
 
     return x, y, count + 1, np.maximum(np.abs(err_abs_x / x), np.abs(err_abs_y / y))
+
+def depends_on_optional(module_name: str):
+    def decorator(func):
+        @wraps(func)
+        def wrapper(*args, **kwargs):
+            spec = find_spec(module_name)
+            if spec is None:
+                raise ImportError(
+                    f"Optional dependency {module_name} not found ({func.__name__})."
+                )
+            else:
+                return func(*args, **kwargs)
+
+        return wrapper
+
+    return decorator

--- a/thermohl-docs/docs/getting-started.md
+++ b/thermohl-docs/docs/getting-started.md
@@ -6,22 +6,38 @@ License, v. 2.0. If a copy of the MPL was not distributed with this
 file, You can obtain one at http://mozilla.org/MPL/2.0/.
 SPDX-License-Identifier: MPL-2.0
 -->
-## Installation
 
-### Using pip
+## Users
+
+---
+
+### Environment
+ThermOHL is using pip for project and dependencies management.
+You need a compatible version of python (3.8 or higher). You may have to install it manually (e.g. with pyenv). Then you may create a virtualenv and activate it.
+
+### Set up thermohl
 
 To install the package using pip, execute the following command:
 
 ```shell
-    python -m pip install thermohl@git+https://github.com/phlowers/thermohl
+    pip install thermohl
 ```
 
-## Development
+Use it ! You can report to the user guide section.
+```shell
+    import thermohl
+    print(thermohl.__version__)
+```
+
+## Developers
+
+---
 
 Install the development dependencies and program scripts via
 
 ```shell
-  pip install -e .[dev]
+  pip install -e .
+  pip install --group dev
 ```
 
 Build a new wheel via
@@ -40,7 +56,7 @@ First, make sure you have mkdocs and the Readthedocs theme installed.
 If you use pip, open a terminal and enter the following commands:
 
 ```shell 
-  pip install -e .[docs]
+  pip install --group docs
 ```
 
 Then, in the same terminal, build the doc with:


### PR DESCRIPTION
- Introduced compatibility adjustments for `scipy` under conditional imports with fallback warnings if unavailable.
- Added `depends_on_optional` decorator for runtime checks of optional dependencies.
- Restructured `pyproject.toml` to manage optional dependencies.
- Updated README with refined installation instructions and user guide enhancements.
- Migrated `__version__` extraction to use `importlib.metadata` for better standardization.
