### PR TITLE
fix(#70): Move to sonarqube-scan-action@v6

### DIFF
--- a/.github/workflows/sonarcloud-analysis.yml
+++ b/.github/workflows/sonarcloud-analysis.yml
@@ -64,6 +64,7 @@ jobs:
           git checkout ${{ github.event.workflow_run.head_branch }}
           git clean -ffdx && git reset --hard HEAD
 
+
       - name: Install uv and Set up Python
         uses: astral-sh/setup-uv@v7
         with:
@@ -80,24 +81,24 @@ jobs:
 
       - name: Run Sonar analysis (Pull Request)
         if: github.event.workflow_run.event == 'pull_request'
-        uses: sonarsource/sonarqube-scan-action@v5
+        uses: sonarsource/sonarqube-scan-action@v6
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           args: >
-            -Dsonar.pullrequest.branch=${{ fromJson(steps.get_pr_data.outputs.data).head.ref }}
-            -Dsonar.pullrequest.key=${{ fromJson(steps.get_pr_data.outputs.data).number }}
-            -Dsonar.pullrequest.base=${{ fromJson(steps.get_pr_data.outputs.data).base.ref }}
-            -Dsonar.scm.revision=${{ github.event.workflow_run.head_sha }}
+            "-Dsonar.pullrequest.branch=${{ fromJson(steps.get_pr_data.outputs.data).head.ref }}"
+            "-Dsonar.pullrequest.key=${{ fromJson(steps.get_pr_data.outputs.data).number }}"
+            "-Dsonar.pullrequest.base=${{ fromJson(steps.get_pr_data.outputs.data).base.ref }}"
+            "-Dsonar.scm.revision=${{ github.event.workflow_run.head_sha }}"
 
       - name: Run Sonar analysis (Push)
         if: github.event.workflow_run.event == 'push' && github.repository == 'phlowers/thermohl'
-        uses: sonarsource/sonarqube-scan-action@v5
+        uses: sonarsource/sonarqube-scan-action@v6
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           args: >
-            -Dsonar.scm.revision=${{ github.event.workflow_run.head_sha }}
-            -Dsonar.branch.name=${{ github.event.workflow_run.head_branch }}
+            "-Dsonar.scm.revision=${{ github.event.workflow_run.head_sha }}"
+            "-Dsonar.branch.name=${{ github.event.workflow_run.head_branch }}"


### PR DESCRIPTION
**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
Fixes #72 


As the sonarqube analysis workflow is a workflow_run type, the version of the executed pipeline is the one of the main branch. As a result, it cannot be tested before being merged