### PR TITLE
security: Update dependencies to fix security vulnerabilities

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,18 +59,21 @@ docs = [
     "mkdocs >= 1.6.1",
     "mkdocs-jupyter == 0.26.3",
     # temporary constraint to avoid security vulnerabilities
-    # in nbconvert
     # see https://github.com/phlowers/thermohl/security/dependabot/17
     # and https://github.com/phlowers/thermohl/security/dependabot/18
     "nbconvert >= 7.17.1",
     # temporary constraint to avoid security vulnerabilities
-    # in mistune
     # see https://github.com/phlowers/thermohl/security/dependabot/19
     "mistune >= 3.2.1",
     # temporary constraint to avoid security vulnerabilities
-    # in urllib3
     # see https://github.com/phlowers/thermohl/security/dependabot/23
     "urllib3 >= 2.7.0",
+    # temporary constraint to avoid security vulnerabilities
+    # see https://github.com/phlowers/thermohl/security/dependabot/28
+    "idna >= 3.15",
+    # temporary constraint to avoid security vulnerabilities
+    # see https://github.com/phlowers/thermohl/security/dependabot/27
+    "pymdown-extensions >= 10.21.3",
     "mkdocs-material >= 9.7.6",
     "mkdocstrings[python] >= 0.29.0",
     "markdown_extensions >= 0.0.1",

--- a/uv.lock
+++ b/uv.lock
@@ -833,11 +833,11 @@ wheels = [
 
 [[package]]
 name = "idna"
-version = "3.11"
+version = "3.17"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/0703ccc57f3a7233505399edb88de3cbd678da106337b9fcde432b65ed60/idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902", size = 194582, upload-time = "2025-10-12T14:55:20.501Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b9/28/99c51f664567218d824af024c0251650fb27e4ca066df188dab0769c5b91/idna-3.17.tar.gz", hash = "sha256:5eb0cb53bc467c12eadcf6de83163ad8527cec9416f44b9b61b19caedad2b87f", size = 196048, upload-time = "2026-05-28T14:32:38.55Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea", size = 71008, upload-time = "2025-10-12T14:55:18.883Z" },
+    { url = "https://files.pythonhosted.org/packages/de/a7/f76514cc40ad6234098ecdebda08732d75964776c51a42845b7da10649e2/idna-3.17-py3-none-any.whl", hash = "sha256:466e48829084efe2548012b855df21540b96f2e20e51bd124c851536556a592c", size = 65316, upload-time = "2026-05-28T14:32:37.035Z" },
 ]
 
 [[package]]
@@ -2426,15 +2426,15 @@ wheels = [
 
 [[package]]
 name = "pymdown-extensions"
-version = "10.21.2"
+version = "10.21.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "markdown" },
     { name = "pyyaml" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/df/08/f1c908c581fd11913da4711ea7ba32c0eee40b0190000996bb863b0c9349/pymdown_extensions-10.21.2.tar.gz", hash = "sha256:c3f55a5b8a1d0edf6699e35dcbea71d978d34ff3fa79f3d807b8a5b3fa90fbdc", size = 853922, upload-time = "2026-03-29T15:01:55.233Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/9e/26/d1015444da4d952a1ca487a236b522eb979766f0295a0bd0c5fc089989a9/pymdown_extensions-10.21.3.tar.gz", hash = "sha256:72cfcf55f07aea0d4af2c4f11dd4e52466ddfb1bb819673146398e0bd3a77354", size = 854140, upload-time = "2026-05-13T12:57:32.267Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f7/27/a2fc51a4a122dfd1015e921ae9d22fee3d20b0b8080d9a704578bf9deece/pymdown_extensions-10.21.2-py3-none-any.whl", hash = "sha256:5c0fd2a2bea14eb39af8ff284f1066d898ab2187d81b889b75d46d4348c01638", size = 268901, upload-time = "2026-03-29T15:01:53.244Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/85/545a951eecc270fcd688288c600017e2050a1aacb56c711d208586d3e470/pymdown_extensions-10.21.3-py3-none-any.whl", hash = "sha256:d7a5d08014fc571e80ca21dd6f854e31f94c489800350564d55d15b3c41e76b6", size = 269002, upload-time = "2026-05-13T12:57:30.296Z" },
 ]
 
 [[package]]
@@ -3037,6 +3037,7 @@ dev = [
     { name = "ruff" },
 ]
 docs = [
+    { name = "idna" },
     { name = "ipykernel" },
     { name = "ipython", version = "8.39.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "ipython", version = "9.10.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
@@ -3053,6 +3054,7 @@ docs = [
     { name = "mkdocstrings", extra = ["python"] },
     { name = "mypy" },
     { name = "nbconvert" },
+    { name = "pymdown-extensions" },
     { name = "ruff" },
     { name = "urllib3" },
 ]
@@ -3093,6 +3095,7 @@ dev = [
     { name = "ruff", specifier = "==0.6.1" },
 ]
 docs = [
+    { name = "idna", specifier = ">=3.15" },
     { name = "ipykernel", specifier = ">=6.30.1" },
     { name = "ipython", specifier = ">=8.18.1" },
     { name = "markdown-extensions", specifier = ">=0.0.1" },
@@ -3107,6 +3110,7 @@ docs = [
     { name = "mkdocstrings", extras = ["python"], specifier = ">=0.29.0" },
     { name = "mypy", specifier = ">=1.13.0" },
     { name = "nbconvert", specifier = ">=7.17.1" },
+    { name = "pymdown-extensions", specifier = ">=10.21.3" },
     { name = "ruff", specifier = "==0.6.1" },
     { name = "urllib3", specifier = ">=2.7.0" },
 ]


### PR DESCRIPTION
	Fixes following vulnerabilities:
		- https://github.com/phlowers/thermohl/security/dependabot/27
		- https://github.com/phlowers/thermohl/security/dependabot/28

**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No
