### PR TITLE
feat: Add user-friendly functions for nebulosity and global/diffuse radiation

### DIFF
--- a/src/thermohl/power/rte/solar_heating.py
+++ b/src/thermohl/power/rte/solar_heating.py
@@ -22,6 +22,70 @@ logger = logging.getLogger(__name__)
 TOL = 1e-06
 
 
+class RadiationIncompatibleWithParameters(ValueError):
+    """Raised when attempting to estimate a nebulosity for a radiation
+    which is not compatible with the other parameters.
+
+    This means the described situation is physically impossible."""
+
+    def __init__(self, *args, **kwargs):
+        self.message = (
+            "It's impossible to have this radiation level with given parameters."
+        )
+        super().__init__(*args, **kwargs)
+
+
+def diffuse_and_beam_radiations(
+    datetime_utc: np.ndarray,
+    latitude: np.ndarray,
+    longitude: np.ndarray,
+    nebulosity: np.ndarray,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Compute diffuse radiation and beam radiation.
+
+    :param datetime_utc: Array of datetimes (more precisely np.datetime64). The year is indifferent.
+    :param latitude: Array of latitudes.
+    :param longitude: Array of longitudes.
+    :param nebulosity: Array of nebulosities (integer between 0 and 8).
+    :return: Tuple of (diffuse_radiation, beam_radiation) in W/m².
+    """
+    solar_hour = sun.utc2solar_hour(datetime_utc, np.deg2rad(longitude))
+    solar_altitude = sun.solar_altitude(np.deg2rad(latitude), datetime_utc, solar_hour)
+    global_radiation = compute_global_radiation(solar_altitude, nebulosity)
+    diffuse_radiation = compute_diffuse_radiation(global_radiation, nebulosity)
+    beam_radiation = compute_beam_radiation(
+        global_radiation, diffuse_radiation, solar_altitude
+    )
+    return diffuse_radiation, beam_radiation
+
+
+def estimate_nebulosity(
+    diffuse_plus_beam_radiation: np.ndarray,
+    datetime_utc: np.ndarray,
+    latitude: np.ndarray,
+    longitude: np.ndarray,
+):
+    """Estimate nebulosity from measured diffuse radiation + beam radiation.
+
+    The results are rounded to the values which give the closest radiation sums.
+
+    Raises RadiationIncompatibleWithParameters if it's impossible to have
+    this radiation level with given parameters (datetime_utc, latitude and longitude).
+
+    :param diffuse_plus_beam_solar_flow: Array of diffuse radiation + beam radiation (in W/m²).
+    :param datetime_utc: Array of datetimes (more precisely np.datetime64). The year is indifferent.
+    :param latitude: Array of latitudes.
+    :param longitude: Array of longitudes.
+    :return: Nebulosities (intgers between 0 and 8, or nan if it can't be computed because of the night).
+    """
+    solar_hour = sun.utc2solar_hour(datetime_utc, np.deg2rad(longitude))
+    solar_altitude = sun.solar_altitude(np.deg2rad(latitude), datetime_utc, solar_hour)
+    return estimate_nebulosity_from_diffuse_and_beam_radiation(
+        solar_altitude,
+        diffuse_plus_beam_radiation,
+    )
+
+
 def compute_global_radiation(
     solar_altitude: floatArrayLike, nebulosity: floatArrayLike
 ) -> floatArrayLike:
@@ -126,7 +190,7 @@ def estimate_nebulosity_from_diffuse_and_beam_radiation(
 
     For solar_altitude values corresponding to the night, the result is nan.
     Else, if no nebulosity could yield the given radiation (e.g. given radiation
-    is too high for given solar altitude), it raises a ValueError.
+    is too high for given solar altitude), it raises a RadiationIncompatibleWithParameters.
 
     Args:
         solar_altitude(float): solar altitude in radians.
@@ -153,10 +217,14 @@ def estimate_nebulosity_from_diffuse_and_beam_radiation(
     else:
         output_shape = (1,)
 
-    # Very few iterations are needed because we want an integer approximate answer
-    nebulosity, _ = bisect_v(
-        f, lower_bound, upper_bound, output_shape, max_iterations=4
-    )
+    try:
+        # Very few iterations are needed because we want an integer approximate answer
+        nebulosity, _ = bisect_v(
+            f, lower_bound, upper_bound, output_shape, max_iterations=4
+        )
+    except ValueError:
+        raise RadiationIncompatibleWithParameters()
+
     rounded_down = np.floor(nebulosity)
     rounded_up = np.ceil(nebulosity)
     nebulosity = np.where(

--- a/src/thermohl/power/rte/solar_heating.py
+++ b/src/thermohl/power/rte/solar_heating.py
@@ -22,7 +22,7 @@ logger = logging.getLogger(__name__)
 TOL = 1e-06
 
 
-class RadiationIncompatibleWithParameters(ValueError):
+class RadiationIncompatibleWithParametersError(ValueError):
     """Raised when attempting to estimate a nebulosity for a radiation
     which is not compatible with the other parameters.
 
@@ -71,7 +71,7 @@ def estimate_nebulosity(
 
     The results are rounded to the values which give the closest radiation sums.
 
-    Raises RadiationIncompatibleWithParameters if it's impossible to have
+    Raises RadiationIncompatibleWithParametersError if it's impossible to have
     this radiation level with given parameters (datetime_utc, latitude and longitude).
 
     Args:
@@ -194,7 +194,7 @@ def estimate_nebulosity_from_diffuse_and_beam_radiation(
 
     For solar_altitude values corresponding to the night, the result is nan.
     Else, if no nebulosity could yield the given radiation (e.g. given radiation
-    is too high for given solar altitude), it raises a RadiationIncompatibleWithParameters.
+    is too high for given solar altitude), it raises a RadiationIncompatibleWithParametersError.
 
     Args:
         solar_altitude(float): solar altitude in radians.
@@ -227,7 +227,7 @@ def estimate_nebulosity_from_diffuse_and_beam_radiation(
             f, lower_bound, upper_bound, output_shape, max_iterations=4
         )
     except ValueError:
-        raise RadiationIncompatibleWithParameters()
+        raise RadiationIncompatibleWithParametersError()
 
     rounded_down = np.floor(nebulosity)
     rounded_up = np.ceil(nebulosity)

--- a/src/thermohl/power/rte/solar_heating.py
+++ b/src/thermohl/power/rte/solar_heating.py
@@ -43,11 +43,13 @@ def diffuse_and_beam_radiations(
 ) -> tuple[np.ndarray, np.ndarray]:
     """Compute diffuse radiation and beam radiation.
 
-    :param datetime_utc: Array of datetimes (more precisely np.datetime64). The year is indifferent.
-    :param latitude: Array of latitudes.
-    :param longitude: Array of longitudes.
-    :param nebulosity: Array of nebulosities (integer between 0 and 8).
-    :return: Tuple of (diffuse_radiation, beam_radiation) in W/m².
+    Args:
+        datetime_utc(np.ndarray): Array of datetimes (more precisely np.datetime64). The year is indifferent.
+        latitude(np.ndarray): Array of latitudes.
+        longitude(np.ndarray): Array of longitudes.
+        nebulosity(np.ndarray): Array of nebulosities (integer between 0 and 8).
+    Returns:
+        tuple(np.ndarray, np.ndarray): diffuse_radiation, beam_radiation in W/m².
     """
     solar_hour = sun.utc2solar_hour(datetime_utc, np.deg2rad(longitude))
     solar_altitude = sun.solar_altitude(np.deg2rad(latitude), datetime_utc, solar_hour)
@@ -64,7 +66,7 @@ def estimate_nebulosity(
     datetime_utc: np.ndarray,
     latitude: np.ndarray,
     longitude: np.ndarray,
-):
+) -> np.array:
     """Estimate nebulosity from measured diffuse radiation + beam radiation.
 
     The results are rounded to the values which give the closest radiation sums.
@@ -72,11 +74,13 @@ def estimate_nebulosity(
     Raises RadiationIncompatibleWithParameters if it's impossible to have
     this radiation level with given parameters (datetime_utc, latitude and longitude).
 
-    :param diffuse_plus_beam_solar_flow: Array of diffuse radiation + beam radiation (in W/m²).
-    :param datetime_utc: Array of datetimes (more precisely np.datetime64). The year is indifferent.
-    :param latitude: Array of latitudes.
-    :param longitude: Array of longitudes.
-    :return: Nebulosities (intgers between 0 and 8, or nan if it can't be computed because of the night).
+    Args:
+        diffuse_plus_beam_solar_flow(np.ndarray): Array of diffuse radiation + beam radiation (in W/m²).
+        datetime_utc(np.ndarray): Array of datetimes (more precisely np.datetime64). The year is indifferent.
+        latitude(np.ndarray): Array of latitudes.
+        longitude(np.ndarray): Array of longitudes.
+    Returns:
+        np.ndarray: Nebulosities (integers between 0 and 8, or nan if it can't be computed because of the night).
     """
     solar_hour = sun.utc2solar_hour(datetime_utc, np.deg2rad(longitude))
     solar_altitude = sun.solar_altitude(np.deg2rad(latitude), datetime_utc, solar_hour)

--- a/src/thermohl/solver/parameters.py
+++ b/src/thermohl/solver/parameters.py
@@ -18,6 +18,9 @@ class DEFAULT_PARAMETERS:
     imax = 9999.0
 
 
+DEFAULT_ALBEDO = 0.15
+
+
 class Parameters:
     """Object to store Solver args in a dict-like manner."""
 
@@ -51,7 +54,7 @@ class Parameters:
         self.wind_speed = 0.0  # wind speed (m.s**-1)
         self.wind_azimuth = 90.0  # wind_azimuth (deg, regarding north)
         self.nebulosity = np.nan  # nebulosity (1)
-        self.albedo = 0.15  # albedo (1)
+        self.albedo = DEFAULT_ALBEDO  # albedo (1)
         # coefficient for air pollution from 0 (clean) to 1 (polluted)
         self.turbidity = 0.1
         self.transit = 100.0  # transit intensity (A)

--- a/test/unit/power/rte/test_power_rte_solar_heating.py
+++ b/test/unit/power/rte/test_power_rte_solar_heating.py
@@ -19,7 +19,7 @@ from thermohl.power.rte.solar_heating import (
     compute_global_radiation,
     compute_diffuse_radiation,
     compute_beam_radiation,
-    RadiationIncompatibleWithParameters,
+    RadiationIncompatibleWithParametersError,
 )
 
 
@@ -262,7 +262,7 @@ def test_estimate_nebulosity_from_diffuse_and_beam_radiation__no_solution() -> N
         global_radiation, diffuse_radiation, solar_altitude
     )
 
-    with pytest.raises(RadiationIncompatibleWithParameters):
+    with pytest.raises(RadiationIncompatibleWithParametersError):
         estimate_nebulosity_from_diffuse_and_beam_radiation(
             solar_altitude, diffuse_radiation + beam_radiation
         )
@@ -287,7 +287,7 @@ def test_estimate_nebulosity__array_no_solution() -> None:
     datetime_utc = np.array([np.datetime64("2026-06-15T00:00:00")])
     latitude = np.array([45.0])
     longitude = np.array([20.0])
-    with pytest.raises(RadiationIncompatibleWithParameters):
+    with pytest.raises(RadiationIncompatibleWithParametersError):
         estimate_nebulosity(
             diffuse_plus_beam_radiation,
             datetime_utc,

--- a/test/unit/power/rte/test_power_rte_solar_heating.py
+++ b/test/unit/power/rte/test_power_rte_solar_heating.py
@@ -13,10 +13,13 @@ import numpy as np
 from thermohl.power.rte.solar_heating import (
     compute_solar_irradiance,
     SolarHeating,
+    diffuse_and_beam_radiations,
+    estimate_nebulosity,
     estimate_nebulosity_from_diffuse_and_beam_radiation,
     compute_global_radiation,
     compute_diffuse_radiation,
     compute_beam_radiation,
+    RadiationIncompatibleWithParameters,
 )
 
 
@@ -166,6 +169,27 @@ def test_solar_irradiance_ignored_by_rte_solar_heating():
     assert np.allclose(solar_heating_1.value(100), solar_heating_2.value(100))
 
 
+def test_diffuse_and_beam_radiations() -> None:
+    datetime_utc = np.array(
+        [
+            np.datetime64("2026-06-15T00:00"),
+            np.datetime64("2026-06-15T06:00"),
+            np.datetime64("2026-06-15T12:00"),
+        ]
+    )
+    latitude = np.array([48, 48, 48])
+    longitude = np.array([21, 21, 21])
+    nebulosity = np.array([0, 2, 8])
+    diffuse_radiation, beam_radiation = diffuse_and_beam_radiations(
+        datetime_utc,
+        latitude,
+        longitude,
+        nebulosity,
+    )
+    print(diffuse_radiation)
+    print(beam_radiation)
+
+
 @pytest.mark.parametrize(
     "input_nebulosity, solar_altitude, expected_nebulosity",
     [
@@ -238,7 +262,35 @@ def test_estimate_nebulosity_from_diffuse_and_beam_radiation__no_solution() -> N
         global_radiation, diffuse_radiation, solar_altitude
     )
 
-    with pytest.raises(ValueError):
+    with pytest.raises(RadiationIncompatibleWithParameters):
         estimate_nebulosity_from_diffuse_and_beam_radiation(
             solar_altitude, diffuse_radiation + beam_radiation
+        )
+
+
+def test_estimate_nebulosity__array() -> None:
+    diffuse_plus_beam_radiation = np.array([700])
+    datetime_utc = np.array([np.datetime64("2026-06-15T12:00:00")])
+    latitude = np.array([45.0])
+    longitude = np.array([20.0])
+    nebulosity = estimate_nebulosity(
+        diffuse_plus_beam_radiation,
+        datetime_utc,
+        latitude,
+        longitude,
+    )
+    assert np.allclose(nebulosity, np.array([5]))
+
+
+def test_estimate_nebulosity__array_no_solution() -> None:
+    diffuse_plus_beam_radiation = np.array([700])
+    datetime_utc = np.array([np.datetime64("2026-06-15T00:00:00")])
+    latitude = np.array([45.0])
+    longitude = np.array([20.0])
+    with pytest.raises(RadiationIncompatibleWithParameters):
+        estimate_nebulosity(
+            diffuse_plus_beam_radiation,
+            datetime_utc,
+            latitude,
+            longitude,
         )

--- a/thermohl-docs/docs/docstring/Models/RTE/solar_heating.md
+++ b/thermohl-docs/docs/docstring/Models/RTE/solar_heating.md
@@ -9,4 +9,5 @@ SPDX-License-Identifier: MPL-2.0
 
 # SolarHeating
 ::: thermohl.power.rte.solar_heating.SolarHeating
-::: thermohl.power.rte.solar_heating.estimate_nebulosity_from_diffuse_and_beam_radiation
+::: thermohl.power.rte.solar_heating.estimate_nebulosity
+::: thermohl.power.rte.solar_heating.diffuse_and_beam_radiations


### PR DESCRIPTION
- Add following functions to estimate nebulosity or compute diffuse radiation and beam radiation:
```python
def diffuse_and_beam_radiations(
    datetime_utc: np.ndarray,
    latitude: np.ndarray,
    longitude: np.ndarray,
    nebulosity: np.ndarray,
) -> tuple[np.ndarray, np.ndarray]: ...


def estimate_nebulosity(
    diffuse_plus_beam_radiation: np.ndarray,
    datetime_utc: np.ndarray,
    latitude: np.ndarray,
    longitude: np.ndarray,
) -> np.array: ...
```
These are meant as user-friendly wrappers for existing functions, to handle intermediary computations (solar hour, solar altitude etc.) so that the user doesn't have to care about them.
- Add `RadiationIncompatibleWithParametersError`. `estimate_nebulosity_from_diffuse_and_beam_radiation` used to raise a `ValueError` when given radiation sum was incompatible with the other arguments. It now raises the new `RadiationIncompatibleWithParameters` exception. It derives from `ValueError` so no adaptation is needed. `estimate_nebulosity` raises the same exception.

**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No

**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No