### PR TITLE
 feat: Add user-friendly functions for nebulosity and beam/diffuse radiation

### DIFF
--- a/src/thermohl/errors.py
+++ b/src/thermohl/errors.py
@@ -1,0 +1,19 @@
+# SPDX-FileCopyrightText: 2025 RTE (https://www.rte-france.com)
+
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+# SPDX-License-Identifier: MPL-2.0
+
+
+class RadiationIncompatibleWithParametersError(ValueError):
+    """Raised when attempting to estimate a nebulosity for a radiation
+    which is not compatible with the other parameters (solar_altitude, datetime_utc...).
+
+    This means the described situation is physically impossible."""
+
+    def __init__(self, *args, **kwargs):
+        self.message = (
+            "It's impossible to have this radiation level with given parameters."
+        )
+        super().__init__(*args, **kwargs)

--- a/src/thermohl/power/rte/solar_heating.py
+++ b/src/thermohl/power/rte/solar_heating.py
@@ -15,11 +15,71 @@ from thermohl import (
 from thermohl.power import SolarHeatingBase
 
 from thermohl.utils import bisect_v
+from thermohl import errors as thermohl_errors
+
 
 logger = logging.getLogger(__name__)
 
 
 TOL = 1e-06
+
+
+def diffuse_and_beam_radiations(
+    datetime_utc: np.ndarray,
+    latitude: np.ndarray,
+    longitude: np.ndarray,
+    nebulosity: np.ndarray,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Compute diffuse radiation and beam radiation.
+
+    Args:
+        datetime_utc(np.ndarray): Array of datetimes (more precisely np.datetime64). The year is indifferent.
+        latitude(np.ndarray): Array of latitudes.
+        longitude(np.ndarray): Array of longitudes.
+        nebulosity(np.ndarray): Array of nebulosities (integer between 0 and 8).
+    Returns:
+        tuple(np.ndarray, np.ndarray): diffuse_radiation, beam_radiation in W/m².
+    """
+    if (nebulosity < 0).any() or (nebulosity > 8).any():
+        raise ValueError(f"nebulosity must be between 0 and 8. Got {nebulosity}")
+
+    solar_hour = sun.utc2solar_hour(datetime_utc, np.deg2rad(longitude))
+    solar_altitude = sun.solar_altitude(np.deg2rad(latitude), datetime_utc, solar_hour)
+    global_radiation = compute_global_radiation(solar_altitude, nebulosity)
+    diffuse_radiation = compute_diffuse_radiation(global_radiation, nebulosity)
+    beam_radiation = compute_beam_radiation(
+        global_radiation, diffuse_radiation, solar_altitude
+    )
+    return diffuse_radiation, beam_radiation
+
+
+def estimate_nebulosity(
+    diffuse_plus_beam_radiation: np.ndarray,
+    datetime_utc: np.ndarray,
+    latitude: np.ndarray,
+    longitude: np.ndarray,
+) -> np.array:
+    """Estimate nebulosity from measured diffuse radiation + beam radiation.
+
+    The results are rounded to the values which give the closest radiation sums.
+
+    Raises RadiationIncompatibleWithParametersError if it's impossible to have
+    this radiation level with given parameters (datetime_utc, latitude and longitude).
+
+    Args:
+        diffuse_plus_beam_solar_flow(np.ndarray): Array of diffuse radiation + beam radiation (in W/m²).
+        datetime_utc(np.ndarray): Array of datetimes (more precisely np.datetime64). The year is indifferent.
+        latitude(np.ndarray): Array of latitudes.
+        longitude(np.ndarray): Array of longitudes.
+    Returns:
+        np.ndarray: Nebulosities (integers between 0 and 8, or nan if it can't be computed because of the night).
+    """
+    solar_hour = sun.utc2solar_hour(datetime_utc, np.deg2rad(longitude))
+    solar_altitude = sun.solar_altitude(np.deg2rad(latitude), datetime_utc, solar_hour)
+    return estimate_nebulosity_from_diffuse_and_beam_radiation(
+        solar_altitude,
+        diffuse_plus_beam_radiation,
+    )
 
 
 def compute_global_radiation(
@@ -126,7 +186,7 @@ def estimate_nebulosity_from_diffuse_and_beam_radiation(
 
     For solar_altitude values corresponding to the night, the result is nan.
     Else, if no nebulosity could yield the given radiation (e.g. given radiation
-    is too high for given solar altitude), it raises a ValueError.
+    is too high for given solar altitude), it raises a RadiationIncompatibleWithParametersError.
 
     Args:
         solar_altitude(float): solar altitude in radians.
@@ -153,10 +213,14 @@ def estimate_nebulosity_from_diffuse_and_beam_radiation(
     else:
         output_shape = (1,)
 
-    # Very few iterations are needed because we want an integer approximate answer
-    nebulosity, _ = bisect_v(
-        f, lower_bound, upper_bound, output_shape, max_iterations=4
-    )
+    try:
+        # Very few iterations are needed because we want an integer approximate answer
+        nebulosity, _ = bisect_v(
+            f, lower_bound, upper_bound, output_shape, max_iterations=4
+        )
+    except ValueError:
+        raise thermohl_errors.RadiationIncompatibleWithParametersError()
+
     rounded_down = np.floor(nebulosity)
     rounded_up = np.ceil(nebulosity)
     nebulosity = np.where(

--- a/src/thermohl/solver/parameters.py
+++ b/src/thermohl/solver/parameters.py
@@ -18,6 +18,9 @@ class DEFAULT_PARAMETERS:
     imax = 9999.0
 
 
+DEFAULT_ALBEDO = 0.15
+
+
 class Parameters:
     """Object to store Solver args in a dict-like manner."""
 
@@ -51,7 +54,7 @@ class Parameters:
         self.wind_speed = 0.0  # wind speed (m.s**-1)
         self.wind_azimuth = 90.0  # wind_azimuth (deg, regarding north)
         self.nebulosity = np.nan  # nebulosity (1)
-        self.albedo = 0.15  # albedo (1)
+        self.albedo = DEFAULT_ALBEDO  # albedo (1)
         # coefficient for air pollution from 0 (clean) to 1 (polluted)
         self.turbidity = 0.1
         self.transit = 100.0  # transit intensity (A)

--- a/src/thermohl/solver/parameters.py
+++ b/src/thermohl/solver/parameters.py
@@ -18,9 +18,6 @@ class DEFAULT_PARAMETERS:
     imax = 9999.0
 
 
-DEFAULT_ALBEDO = 0.15
-
-
 class Parameters:
     """Object to store Solver args in a dict-like manner."""
 
@@ -54,7 +51,7 @@ class Parameters:
         self.wind_speed = 0.0  # wind speed (m.s**-1)
         self.wind_azimuth = 90.0  # wind_azimuth (deg, regarding north)
         self.nebulosity = np.nan  # nebulosity (1)
-        self.albedo = DEFAULT_ALBEDO  # albedo (1)
+        self.albedo = 0.15  # albedo (1)
         # coefficient for air pollution from 0 (clean) to 1 (polluted)
         self.turbidity = 0.1
         self.transit = 100.0  # transit intensity (A)

--- a/test/unit/power/rte/test_power_rte_solar_heating.py
+++ b/test/unit/power/rte/test_power_rte_solar_heating.py
@@ -13,11 +13,14 @@ import numpy as np
 from thermohl.power.rte.solar_heating import (
     compute_solar_irradiance,
     SolarHeating,
+    diffuse_and_beam_radiations,
+    estimate_nebulosity,
     estimate_nebulosity_from_diffuse_and_beam_radiation,
     compute_global_radiation,
     compute_diffuse_radiation,
     compute_beam_radiation,
 )
+from thermohl import errors as thermohl_errors
 
 
 def test_compute_solar_irradiance_night():
@@ -166,6 +169,47 @@ def test_solar_irradiance_ignored_by_rte_solar_heating():
     assert np.allclose(solar_heating_1.value(100), solar_heating_2.value(100))
 
 
+def test_diffuse_and_beam_radiations() -> None:
+    datetime_utc = np.array(
+        [
+            np.datetime64("2026-06-15T00:00"),
+            np.datetime64("2026-06-15T06:00"),
+            np.datetime64("2026-06-15T12:00"),
+        ]
+    )
+    latitude = np.array([48, 48, 48])
+    longitude = np.array([21, 21, 21])
+    nebulosity = np.array([0, 2, 8])
+    diffuse_radiation, beam_radiation = diffuse_and_beam_radiations(
+        datetime_utc,
+        latitude,
+        longitude,
+        nebulosity,
+    )
+    assert np.allclose(diffuse_radiation, np.array([0, 149.44519, 189.98370]))
+    assert np.allclose(beam_radiation, np.array([0, 555.11970, 0]))
+
+
+def test_diffuse_and_beam_radiations__wrong_nebulosity() -> None:
+    datetime_utc = np.array(
+        [
+            np.datetime64("2026-06-15T00:00"),
+            np.datetime64("2026-06-15T06:00"),
+            np.datetime64("2026-06-15T12:00"),
+        ]
+    )
+    latitude = np.array([48, 48, 48])
+    longitude = np.array([21, 21, 21])
+    nebulosity = np.array([0, 2, 8.5])
+    with pytest.raises(ValueError):
+        diffuse_and_beam_radiations(
+            datetime_utc,
+            latitude,
+            longitude,
+            nebulosity,
+        )
+
+
 @pytest.mark.parametrize(
     "input_nebulosity, solar_altitude, expected_nebulosity",
     [
@@ -238,7 +282,40 @@ def test_estimate_nebulosity_from_diffuse_and_beam_radiation__no_solution() -> N
         global_radiation, diffuse_radiation, solar_altitude
     )
 
-    with pytest.raises(ValueError):
+    with pytest.raises(thermohl_errors.RadiationIncompatibleWithParametersError):
         estimate_nebulosity_from_diffuse_and_beam_radiation(
             solar_altitude, diffuse_radiation + beam_radiation
+        )
+
+
+def test_estimate_nebulosity__array() -> None:
+    diffuse_plus_beam_radiation = np.array([700, 600])
+    datetime_utc = np.array(
+        [
+            np.datetime64("2026-06-15T12:00:00"),
+            np.datetime64("2026-06-15T12:00:00"),
+        ]
+    )
+    latitude = np.array([45.0, 45.0])
+    longitude = np.array([20.0, 20.0])
+    nebulosity = estimate_nebulosity(
+        diffuse_plus_beam_radiation,
+        datetime_utc,
+        latitude,
+        longitude,
+    )
+    assert np.allclose(nebulosity, np.array([5, 6]))
+
+
+def test_estimate_nebulosity__array_no_solution() -> None:
+    diffuse_plus_beam_radiation = np.array([700])
+    datetime_utc = np.array([np.datetime64("2026-06-15T00:00:00")])
+    latitude = np.array([45.0])
+    longitude = np.array([20.0])
+    with pytest.raises(thermohl_errors.RadiationIncompatibleWithParametersError):
+        estimate_nebulosity(
+            diffuse_plus_beam_radiation,
+            datetime_utc,
+            latitude,
+            longitude,
         )

--- a/thermohl-docs/docs/docstring/errors.md
+++ b/thermohl-docs/docs/docstring/errors.md
@@ -7,7 +7,6 @@ file, You can obtain one at http://mozilla.org/MPL/2.0/.
 SPDX-License-Identifier: MPL-2.0
 -->
 
-# SolarHeating
-::: thermohl.power.rte.solar_heating.SolarHeating
-::: thermohl.power.rte.solar_heating.estimate_nebulosity
-::: thermohl.power.rte.solar_heating.diffuse_and_beam_radiations
+# Errors
+
+::: thermohl.errors

--- a/thermohl-docs/docs/examples/nebulosity_and_radiation.ipynb
+++ b/thermohl-docs/docs/examples/nebulosity_and_radiation.ipynb
@@ -1,0 +1,144 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1fde8e0a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pytest\n",
+    "\n",
+    "import numpy as np\n",
+    "\n",
+    "from thermohl.power.rte.solar_heating import (\n",
+    "    diffuse_and_beam_radiations,\n",
+    "    estimate_nebulosity,\n",
+    ")\n",
+    "\n",
+    "from thermohl import errors as thermohl_errors\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bf3769d7",
+   "metadata": {},
+   "source": [
+    "You may compute nebulosity from a measured solar flow i.e. diffuse radiation + beam radiation, the date and time (the year is indifferent, feel free to use an arbitrary value), and the GPS coordinates.\n",
+    "\n",
+    "(Please note that diffuse radiation + beam radiation does not equal global radiation, be sure to use the right radiation types.)\n",
+    "\n",
+    "The result is rounded to the value which gives the closest solar flow to the input solar flow. So, the solar flow derived from the computed nebulosity will probably not be exactly the same as the measured solar flow."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "427d5e77",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "datetime_utc = np.array([\n",
+    "    np.datetime64(\"2026-06-15T14:00:00\"),\n",
+    "    np.datetime64(\"2026-06-15T14:00:00\"),\n",
+    "])\n",
+    "latitude = np.array([45.0, 45.0])\n",
+    "longitude = np.array([20.0, 20.0])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ce6a2446",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "nebulosity = np.array([0., 8.])\n",
+    "\n",
+    "diffuse_radiation, beam_radiation = diffuse_and_beam_radiations(\n",
+    "    datetime_utc,\n",
+    "    latitude,\n",
+    "    longitude,\n",
+    "    nebulosity,\n",
+    ")\n",
+    "print(f\"{diffuse_radiation=}\")\n",
+    "print(f\"{beam_radiation=}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7bce89b1",
+   "metadata": {},
+   "source": [
+    "You may do the opposite: compute diffuse radiation and beam radiation from a nebulosity, as well as datetime_utc (the year doesn't matter here either) and GPS coordinates."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2b2e0fab",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "radiation_sum = diffuse_radiation + beam_radiation\n",
+    "\n",
+    "print(f\"{radiation_sum=}\")\n",
+    "\n",
+    "nebulosity_estimate = estimate_nebulosity(\n",
+    "    radiation_sum,\n",
+    "    datetime_utc,\n",
+    "    latitude,\n",
+    "    longitude,\n",
+    ")\n",
+    "print(f\"{nebulosity_estimate=}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2acd009e",
+   "metadata": {},
+   "source": [
+    "If the sum diffuse radiation + beam radiation is higher than the highest possible radiation sum with given datetime and GPS coordinates, this function raises an error."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b3328d09",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "radiation_sum += np.array([500, 600])\n",
+    "\n",
+    "with pytest.raises(thermohl_errors.RadiationIncompatibleWithParametersError):\n",
+    "    estimate_nebulosity(\n",
+    "        radiation_sum,\n",
+    "        datetime_utc,\n",
+    "        latitude,\n",
+    "        longitude,\n",
+    "    )"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "thermohl (3.12.12.final.0)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/thermohl-docs/mkdocs.yml
+++ b/thermohl-docs/mkdocs.yml
@@ -77,7 +77,7 @@ nav:
           - Solver 1 temperature: docstring/Solvers/Solver1T/solver_1_temperature.md
           - Solver 3 temperatures: docstring/Solvers/Solver3T/solver_3_temperature.md
           - Solver 3 temperatures RTE: docstring/Solvers/Solver3TL/solver_3_temperature_rte.md
-
+      - Errors: docstring/errors.md
 
 
 plugins:


### PR DESCRIPTION
- Add following functions to estimate nebulosity or compute diffuse radiation and beam radiation:
```python
def diffuse_and_beam_radiations(
    datetime_utc: np.ndarray,
    latitude: np.ndarray,
    longitude: np.ndarray,
    nebulosity: np.ndarray,
) -> tuple[np.ndarray, np.ndarray]: ...


def estimate_nebulosity(
    diffuse_plus_beam_radiation: np.ndarray,
    datetime_utc: np.ndarray,
    latitude: np.ndarray,
    longitude: np.ndarray,
) -> np.array: ...
```
These are meant as user-friendly wrappers for existing functions, to handle intermediary computations (solar hour, solar altitude etc.) so that the user doesn't have to care about them.
- Add `RadiationIncompatibleWithParametersError`. `estimate_nebulosity_from_diffuse_and_beam_radiation` used to raise a `ValueError` when given radiation sum was incompatible with the other arguments. It now raises the new `RadiationIncompatibleWithParameters` exception. It derives from `ValueError` so no adaptation is needed. `estimate_nebulosity` raises the same exception.
- Add documentation and an example notebook which demonstrates the use of `diffuse_and_beam_radiations` and `estimate_nebulosity`.


**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
https://github.com/phlowers/thermohl/issues/111
https://github.com/phlowers/thermohl/issues/110

**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No