### PR TITLE
Add solar_irradiance function

### DIFF
--- a/src/thermohl/power/rte/solar_heating.py
+++ b/src/thermohl/power/rte/solar_heating.py
@@ -21,8 +21,6 @@ logger = logging.getLogger(__name__)
 
 TOL = 1e-06
 
-DEFAULT_ALBEDO = 0.15
-
 
 def diffuse_and_beam_radiations(
     datetime_utc: np.ndarray,
@@ -85,6 +83,7 @@ def solar_irradiance(
     longitude: np.ndarray,
     nebulosity: np.ndarray,
     cable_azimuth: np.ndarray,
+    albedo: np.ndarray | None = None,
 ) -> np.ndarray:
     """Compute solar irradiance.
 
@@ -99,10 +98,15 @@ def solar_irradiance(
         longitude(np.array): longitude.
         nebulosity(np.array): nebulosity (integers between 0 and 8).
         cable_azimuth(np.array): cable azimuth.
+        albedo(np.array | None): albedo (describes how the ground reflects radiation).
+            If not provided, a default value of 0.15 will be used.
 
     Returns:
         Solar irradiance value.
     """
+    if albedo is None:
+        albedo = np.full_like(datetime_utc, 0.15)
+
     solar_hour = sun.utc2solar_hour(datetime_utc, np.deg2rad(longitude))
     solar_altitude = sun.solar_altitude(np.deg2rad(latitude), datetime_utc, solar_hour)
     global_radiation = compute_global_radiation(solar_altitude, nebulosity)
@@ -115,7 +119,7 @@ def solar_irradiance(
         solar_altitude,
         incidence,
         nebulosity,
-        albedo=DEFAULT_ALBEDO,
+        albedo,
     )
 
 

--- a/src/thermohl/power/rte/solar_heating.py
+++ b/src/thermohl/power/rte/solar_heating.py
@@ -105,7 +105,7 @@ def solar_irradiance(
         Solar irradiance value.
     """
     if albedo is None:
-        albedo = np.full_like(datetime_utc, 0.15)
+        albedo = np.full_like(latitude, 0.15)
 
     solar_hour = sun.utc2solar_hour(datetime_utc, np.deg2rad(longitude))
     solar_altitude = sun.solar_altitude(np.deg2rad(latitude), datetime_utc, solar_hour)

--- a/src/thermohl/power/rte/solar_heating.py
+++ b/src/thermohl/power/rte/solar_heating.py
@@ -105,7 +105,7 @@ def solar_irradiance(
         Solar irradiance value.
     """
     if albedo is None:
-        albedo = np.full_like(latitude, 0.15)
+        albedo = np.full_like(latitude, 0.15, dtype=float)
 
     solar_hour = sun.utc2solar_hour(datetime_utc, np.deg2rad(longitude))
     solar_altitude = sun.solar_altitude(np.deg2rad(latitude), datetime_utc, solar_hour)

--- a/src/thermohl/power/rte/solar_heating.py
+++ b/src/thermohl/power/rte/solar_heating.py
@@ -13,13 +13,14 @@ from thermohl import (
     datetimeArrayLike,
 )
 from thermohl.power import SolarHeatingBase
-
 from thermohl.utils import bisect_v
 
 logger = logging.getLogger(__name__)
 
 
 TOL = 1e-06
+
+DEFAULT_ALBEDO = 0.15
 
 
 def diffuse_and_beam_radiations(
@@ -74,6 +75,29 @@ def estimate_nebulosity(
     return estimate_nebulosity_from_diffuse_and_beam_radiation(
         solar_altitude,
         diffuse_plus_beam_radiation,
+    )
+
+
+def solar_irradiance(
+    datetime_utc: np.ndarray,
+    latitude: np.ndarray,
+    longitude: np.ndarray,
+    nebulosity: np.ndarray,
+    cable_azimuth: np.ndarray,
+) -> np.ndarray:
+    solar_hour = sun.utc2solar_hour(datetime_utc, np.deg2rad(longitude))
+    solar_altitude = sun.solar_altitude(np.deg2rad(latitude), datetime_utc, solar_hour)
+    global_radiation = compute_global_radiation(solar_altitude, nebulosity)
+    solar_azimuth_rad = sun.solar_azimuth(
+        np.deg2rad(latitude), datetime_utc, solar_hour
+    )
+    incidence = compute_incidence(solar_altitude, solar_azimuth_rad, cable_azimuth)
+    return compute_solar_irradiance(  # type: ignore
+        global_radiation,
+        solar_altitude,
+        incidence,
+        nebulosity,
+        albedo=DEFAULT_ALBEDO,
     )
 
 
@@ -224,6 +248,16 @@ def estimate_nebulosity_from_diffuse_and_beam_radiation(
     return np.where(np.sin(solar_altitude) <= TOL, np.nan, nebulosity)
 
 
+def compute_incidence(
+    solar_altitude: floatArrayLike,
+    solar_azimuth_rad: floatArrayLike,
+    cable_azimuth: floatArrayLike,
+) -> floatArrayLike:
+    return np.arccos(
+        np.cos(solar_altitude) * np.cos(solar_azimuth_rad - np.deg2rad(cable_azimuth))
+    )
+
+
 class SolarHeating(SolarHeatingBase):
     def __init__(
         self,
@@ -268,10 +302,7 @@ class SolarHeating(SolarHeatingBase):
             measured_global_radiation, nebulosity, solar_altitude
         )
         solar_azimuth_rad = sun.solar_azimuth(np.deg2rad(latitude), date, solar_hour)
-        incidence = np.arccos(
-            np.cos(solar_altitude)
-            * np.cos(solar_azimuth_rad - np.deg2rad(cable_azimuth))
-        )
+        incidence = compute_incidence(solar_altitude, solar_azimuth_rad, cable_azimuth)
 
         self.solar_absorptivity = solar_absorptivity
         self.outer_diameter = outer_diameter

--- a/src/thermohl/power/rte/solar_heating.py
+++ b/src/thermohl/power/rte/solar_heating.py
@@ -7,6 +7,7 @@
 import logging
 from typing import Any, Tuple
 import numpy as np
+from numpy import typing as npt
 from thermohl import (
     floatArrayLike,
     sun,
@@ -79,12 +80,29 @@ def estimate_nebulosity(
 
 
 def solar_irradiance(
-    datetime_utc: np.ndarray,
+    datetime_utc: npt.NDArray[np.datetime64],
     latitude: np.ndarray,
     longitude: np.ndarray,
     nebulosity: np.ndarray,
     cable_azimuth: np.ndarray,
 ) -> np.ndarray:
+    """Compute solar irradiance.
+
+    Wrapper around compute_solar_irradiance, it computes the same thing
+    but from different inputs.
+    It uses default albedo of 0.15.
+
+    Args:
+        datetime_utc(npt.NDArray[np.datetime64]): datetimes. Year is indifferent,
+            feel free to set an arbitrary value.
+        latitude(np.array): latitude.
+        longitude(np.array): longitude.
+        nebulosity(np.array): nebulosity (integers between 0 and 8).
+        cable_azimuth(np.array): cable azimuth.
+
+    Returns:
+        Solar irradiance value.
+    """
     solar_hour = sun.utc2solar_hour(datetime_utc, np.deg2rad(longitude))
     solar_altitude = sun.solar_altitude(np.deg2rad(latitude), datetime_utc, solar_hour)
     global_radiation = compute_global_radiation(solar_altitude, nebulosity)

--- a/test/unit/power/rte/test_power_rte_solar_heating.py
+++ b/test/unit/power/rte/test_power_rte_solar_heating.py
@@ -368,6 +368,30 @@ def test_solar_irradiance() -> None:
             np.array([1082.90, 284.73]),
         ),
         (
+            np.array(
+                [
+                    np.datetime64("2026-07-01T14:30:00"),
+                ]
+            ),
+            np.array([48]),
+            np.array([-5]),
+            np.array([0]),
+            np.array([0]),
+            np.array([1082.90]),
+        ),
+        (
+            np.array(
+                [
+                    np.datetime64("2026-07-01T14:30:00"),
+                ]
+            ),
+            np.array([49]),
+            np.array([8]),
+            np.array([8]),
+            np.array([360]),
+            np.array([284.73]),
+        ),
+        (
             np.array([np.datetime64("2026-07-01T01:00:30")]),
             np.array([49]),
             np.array([8]),
@@ -378,6 +402,8 @@ def test_solar_irradiance() -> None:
     ],
     ids=[
         "Nominal",
+        "Nominal 1",
+        "Nominal 2",
         "Night",
     ],
 )

--- a/test/unit/power/rte/test_power_rte_solar_heating.py
+++ b/test/unit/power/rte/test_power_rte_solar_heating.py
@@ -339,6 +339,18 @@ def test_estimate_nebulosity__array_night() -> None:
     assert np.isnan(nebulosity[0])
 
 
+def test_solar_irradiance() -> None:
+    result = solar_irradiance(
+        datetime_utc=np.datetime64("2026-07-01T14:30:00"),
+        latitude=np.array([48]),
+        longitude=np.array([-5]),
+        nebulosity=np.array([5]),
+        cable_azimuth=np.array([180]),
+        albedo=np.array([0.12]),
+    )
+    assert np.allclose(result, np.array([957.73]))
+
+
 @pytest.mark.parametrize(
     "datetime_utc, latitude, longitude, nebulosity, cable_azimuth, expected_result",
     [
@@ -369,7 +381,7 @@ def test_estimate_nebulosity__array_night() -> None:
         "Night",
     ],
 )
-def test_solar_irradiance(
+def test_solar_irradiance__default_albedo(
     datetime_utc, latitude, longitude, nebulosity, cable_azimuth, expected_result
 ) -> None:
     result = solar_irradiance(

--- a/test/unit/power/rte/test_power_rte_solar_heating.py
+++ b/test/unit/power/rte/test_power_rte_solar_heating.py
@@ -368,30 +368,6 @@ def test_solar_irradiance() -> None:
             np.array([1082.90, 284.73]),
         ),
         (
-            np.array(
-                [
-                    np.datetime64("2026-07-01T14:30:00"),
-                ]
-            ),
-            np.array([48]),
-            np.array([-5]),
-            np.array([0]),
-            np.array([0]),
-            np.array([1082.90]),
-        ),
-        (
-            np.array(
-                [
-                    np.datetime64("2026-07-01T14:30:00"),
-                ]
-            ),
-            np.array([49]),
-            np.array([8]),
-            np.array([8]),
-            np.array([360]),
-            np.array([284.73]),
-        ),
-        (
             np.array([np.datetime64("2026-07-01T01:00:30")]),
             np.array([49]),
             np.array([8]),
@@ -402,8 +378,6 @@ def test_solar_irradiance() -> None:
     ],
     ids=[
         "Nominal",
-        "Nominal 1",
-        "Nominal 2",
         "Night",
     ],
 )

--- a/test/unit/power/rte/test_power_rte_solar_heating.py
+++ b/test/unit/power/rte/test_power_rte_solar_heating.py
@@ -15,6 +15,7 @@ from thermohl.power.rte.solar_heating import (
     SolarHeating,
     diffuse_and_beam_radiations,
     estimate_nebulosity,
+    solar_irradiance,
     estimate_nebulosity_from_diffuse_and_beam_radiation,
     compute_global_radiation,
     compute_diffuse_radiation,
@@ -336,3 +337,46 @@ def test_estimate_nebulosity__array_night() -> None:
         longitude,
     )
     assert np.isnan(nebulosity[0])
+
+
+@pytest.mark.parametrize(
+    "datetime_utc, latitude, longitude, nebulosity, cable_azimuth, expected_result",
+    [
+        (
+            np.array(
+                [
+                    np.datetime64("2026-07-01T14:30:00"),
+                    np.datetime64("2026-07-01T14:30:00"),
+                ]
+            ),
+            np.array([48, 49]),
+            np.array([-5, 8]),
+            np.array([0, 8]),
+            np.array([0, 360]),
+            np.array([1082.90, 284.73]),
+        ),
+        (
+            np.array([np.datetime64("2026-07-01T01:00:30")]),
+            np.array([49]),
+            np.array([8]),
+            np.array([8]),
+            np.array([360]),
+            np.array([0]),
+        ),
+    ],
+    ids=[
+        "Nominal",
+        "Night",
+    ],
+)
+def test_solar_irradiance(
+    datetime_utc, latitude, longitude, nebulosity, cable_azimuth, expected_result
+) -> None:
+    result = solar_irradiance(
+        datetime_utc,
+        latitude,
+        longitude,
+        nebulosity,
+        cable_azimuth,
+    )
+    assert np.allclose(result, expected_result)

--- a/thermohl-docs/docs/docstring/Models/RTE/solar_heating.md
+++ b/thermohl-docs/docs/docstring/Models/RTE/solar_heating.md
@@ -11,3 +11,4 @@ SPDX-License-Identifier: MPL-2.0
 ::: thermohl.power.rte.solar_heating.SolarHeating
 ::: thermohl.power.rte.solar_heating.estimate_nebulosity
 ::: thermohl.power.rte.solar_heating.diffuse_and_beam_radiations
+::: thermohl.power.rte.solar_heating.solar_irradiance


### PR DESCRIPTION
This does the same as compute_solar_irradiance but from
different inputs. (Also, it only handles numpy arrays.)

Useful for Stellar.

**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No

**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No
