### PR TITLE
Update 3-temperatures solver scheme for transient_temperature method

### DIFF
--- a/src/thermohl/solver/slv3t.py
+++ b/src/thermohl/solver/slv3t.py
@@ -263,12 +263,16 @@ class Solver3T(Solver_):
         time_step: float = 1.0e-05,
     ) -> floatArrayLike:
         """Estimation of a time-constant by linearization of the EDO."""
-        return -(self.args.linear_mass * self.args.heat_capacity) / (
-            self.balance_3t(surface_temperature + time_step, core_temperature)
-            - self.balance_3t(surface_temperature - time_step, core_temperature)
-            + self.balance_3t(surface_temperature, core_temperature + time_step)
-            - self.balance_3t(surface_temperature, core_temperature - time_step)
-        ) * (2 * time_step)
+        return (
+            -(self.args.linear_mass * self.args.heat_capacity)
+            / (
+                self.balance_3t(surface_temperature + time_step, core_temperature)
+                - self.balance_3t(surface_temperature - time_step, core_temperature)
+                + self.balance_3t(surface_temperature, core_temperature + time_step)
+                - self.balance_3t(surface_temperature, core_temperature - time_step)
+            )
+            * (2 * time_step)
+        )
 
     def morgan_3t(
         self,
@@ -523,10 +527,12 @@ class Solver3T(Solver_):
                 surface_temperature[i - 1, :], core_temperature[i - 1, :]
             )
             tau = self.tau(surface_temperature[i - 1, :], core_temperature[i - 1, :])
-            average_temperature[i, :] = average_temperature[i - 1, :] + time_step * bal * imc
+            average_temperature[i, :] = (
+                average_temperature[i - 1, :] + time_step * bal * imc
+            )
             morgan = c1 * (self.joule_heating.value(average_temperature[i, :]) - bal)
-            tx = tx + dt * (-tx + morgan) / (tau * 0.3)
-            ty = ty + dt * (-ty + average_temperature[i - 1, :]) / (tau * 0.02)
+            tx = tx + time_step * (-tx + morgan) / (tau * 0.3)
+            ty = ty + time_step * (-ty + average_temperature[i - 1, :]) / (tau * 0.02)
             core_temperature[i, :] = c2 * tx + ty
             surface_temperature[i, :] = ty - (1 - c2) * tx
 

--- a/src/thermohl/solver/slv3t.py
+++ b/src/thermohl/solver/slv3t.py
@@ -105,7 +105,7 @@ def _infer_target_from_cable_type(
 class Solver3T(Solver_):
     def __init__(
         self,
-        dic: Optional[dict[str, Any]] = None,
+        dic: Optional[Dict[str, Any]] = None,
         joule: Type[PowerTerm] = PowerTerm,
         solar: Type[PowerTerm] = PowerTerm,
         convective: Type[PowerTerm] = PowerTerm,
@@ -255,6 +255,20 @@ class Solver3T(Solver_):
             - self.radiative_cooling.value(surface_temperature)
             - self.precipitation_cooling.value(surface_temperature)
         )
+
+    def tau(
+        self,
+        surface_temperature: floatArray,
+        core_temperature: floatArray,
+        time_step: float = 1.0e-05,
+    ) -> floatArrayLike:
+        """Estimation of a time-constant by linearization of the EDO."""
+        return -(self.args.linear_mass * self.args.heat_capacity) / (
+            self.balance_3t(surface_temperature + time_step, core_temperature)
+            - self.balance_3t(surface_temperature - time_step, core_temperature)
+            + self.balance_3t(surface_temperature, core_temperature + time_step)
+            - self.balance_3t(surface_temperature, core_temperature - time_step)
+        ) * (2 * time_step)
 
     def morgan_3t(
         self,
@@ -493,20 +507,28 @@ class Solver3T(Solver_):
             surface_temperature[0, :], core_temperature[0, :]
         )
 
+        # state variables for the continuity-preserving integration scheme
+        # the solve operation is actually performed on this variables, which have the dimension
+        # of a temperature but no physical meaning of interest, hence the generic names
+        tx = core_temperature[0, :] - surface_temperature[0, :]
+        ty = c2 * surface_temperature[0, :] + (1 - c2) * core_temperature[0, :]
+
         # main time loop
         for i in range(1, len(offset)):
             for k in time_changing_parameters.keys():
                 self.args[k] = time_changing_parameters[k][i, :]
             self.update()
+            time_step = offset[i] - offset[i - 1]
             bal = self.balance_3t(
                 surface_temperature[i - 1, :], core_temperature[i - 1, :]
             )
-            average_temperature[i, :] = (
-                average_temperature[i - 1, :] + (offset[i] - offset[i - 1]) * bal * imc
-            )
-            mrg = c1 * (self.joule_heating.value(average_temperature[i, :]) - bal)
-            core_temperature[i, :] = average_temperature[i, :] + c2 * mrg
-            surface_temperature[i, :] = core_temperature[i, :] - mrg
+            tau = self.tau(surface_temperature[i - 1, :], core_temperature[i - 1, :])
+            average_temperature[i, :] = average_temperature[i - 1, :] + time_step * bal * imc
+            morgan = c1 * (self.joule_heating.value(average_temperature[i, :]) - bal)
+            tx = tx + dt * (-tx + morgan) / (tau * 0.3)
+            ty = ty + dt * (-ty + average_temperature[i - 1, :]) / (tau * 0.02)
+            core_temperature[i, :] = c2 * tx + ty
+            surface_temperature[i, :] = ty - (1 - c2) * tx
 
         result = self._transient_temperature_results(
             offset,


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->

The closest would be the feature, but it can be discussed. It is a small change in beahviour for core and surface temperature in transient mode.

**What is the current behavior?**
<!-- You can also link to an open issue here -->

When using the `Solver3T` (non-legacy) `transient_temperature` method, for steep (non-continuous) changes of transit (respectively wind speed), the core temperature (resp. surface temperature) was also non-continuous. This was okay(ish) since it was following the underlying model which was solved.

**What is the new behavior (if this is a feature change)?**

As a new model has been introduced last year, which ensure continuity off all three temperatures, this PR propose an update to match the solve. 

No test were added since numerical results are not covered. A good point would be to have non-regression tests that cover all heat_equation and model but it is out of the scope of this PR.

**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No

**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
