### PR TITLE
feat: Optionally return whether computation converged for nebulosity

### DIFF
--- a/src/thermohl/__init__.py
+++ b/src/thermohl/__init__.py
@@ -30,6 +30,7 @@ numberArrayLike = Union[float, int, npt.NDArray[np.float64], npt.NDArray[np.int6
 strListLike = Union[str, List[str]]
 dateArrayLike = Union[np.datetime64, npt.NDArray[np.datetime64]]
 datetimeArrayLike = Union[np.datetime64, npt.NDArray[np.datetime64]]
+boolArrayLike = Union[bool, npt.NDArray[np.bool_]]
 
 floatArray = npt.NDArray[np.float64]
 intArray = npt.NDArray[np.int64]

--- a/src/thermohl/power/rte/solar_heating.py
+++ b/src/thermohl/power/rte/solar_heating.py
@@ -12,9 +12,11 @@ from thermohl import (
     floatArrayLike,
     sun,
     datetimeArrayLike,
+    boolArrayLike,
 )
 from thermohl.power import SolarHeatingBase
 from thermohl.utils import bisect_v
+
 
 logger = logging.getLogger(__name__)
 
@@ -56,24 +58,60 @@ def estimate_nebulosity(
     datetime_utc: np.ndarray,
     latitude: np.ndarray,
     longitude: np.ndarray,
-) -> np.array:
+    return_converged: bool = False,
+) -> np.ndarray | tuple[npt.NDArray[np.float64], npt.NDArray[np.bool]]:
     """Estimate nebulosity from measured diffuse radiation + beam radiation.
 
     The results are rounded to the values which give the closest radiation sums.
+    For datetime_utc values corresponding to the night, the result is nan.
 
     Args:
-        diffuse_plus_beam_solar_flow(np.ndarray): Array of diffuse radiation + beam radiation (in W/m²).
-        datetime_utc(np.ndarray): Array of datetimes (more precisely np.datetime64). The year is indifferent.
-        latitude(np.ndarray): Array of latitudes.
-        longitude(np.ndarray): Array of longitudes.
+        diffuse_plus_beam_solar_flow(array): Array of diffuse radiation + beam radiation (in W/m²).
+        datetime_utc(array): Array of datetimes (more precisely np.datetime64). The year is indifferent.
+        latitude(array): Array of latitudes.
+        longitude(array): Array of longitudes.
+        return_converged(bool): if True, output contains information on whether computation converged.
+            Default is False.
+
     Returns:
-        np.ndarray: Nebulosities (integers between 0 and 8, or nan if it can't be computed because of the night).
+        array | tuple[array, array]: Nebulosities (integers between 0 and 8, or nan if it can't be computed because of the night).
+        If return_converged is False, the output is an array.
+        If return_converged is True, the output is a tuple of two arrays: the first contains the nebulosities,
+        the second contains boolean signaling whether computation converged.
+
+    Examples:
+
+    ```python
+    >>> estimate_nebulosity(
+    >>>     np.array([700, 10]),
+            np.array([np.datetime64("2026-06-15T12:00:00"), np.datetime64("2026-06-15T12:00:00")]),
+            np.array([45.0, 45.0]),
+            np.array([20.0, 20.0]),
+    >>> )
+    array([5.0, 8.0])
+    >>> nebulosity, converged = estimate_nebulosity(
+    >>>     np.array([700, 10]),
+            np.array([np.datetime64("2026-06-15T12:00:00"), np.datetime64("2026-06-15T12:00:00")]),
+            np.array([45.0, 45.0]),
+            np.array([20.0, 20.0]),
+            return_converged=True,
+    >>> )
+    >>> nebulosity[0]
+    np.float64(5.0)
+    >>> converged[0]
+    np.True_
+    >>> nebulosity[1]
+    np.float64(8.0)
+    >>> converged[1]
+    np.False_
+    ```
     """
     solar_hour = sun.utc2solar_hour(datetime_utc, np.deg2rad(longitude))
     solar_altitude = sun.solar_altitude(np.deg2rad(latitude), datetime_utc, solar_hour)
     return estimate_nebulosity_from_diffuse_and_beam_radiation(
         solar_altitude,
         diffuse_plus_beam_radiation,
+        return_converged=return_converged,
     )
 
 
@@ -221,8 +259,10 @@ def compute_data_from_provided(
 
 
 def estimate_nebulosity_from_diffuse_and_beam_radiation(
-    solar_altitude: floatArrayLike, radiation_sum: floatArrayLike
-) -> floatArrayLike:
+    solar_altitude: floatArrayLike,
+    radiation_sum: floatArrayLike,
+    return_converged: bool = False,
+) -> floatArrayLike | tuple[floatArrayLike, boolArrayLike]:
     """Estimate nebulosity based on diffuse radiation + beam radiation, and solar altitude.
 
     For solar_altitude values corresponding to the night, the result is nan.
@@ -232,8 +272,32 @@ def estimate_nebulosity_from_diffuse_and_beam_radiation(
     Args:
         solar_altitude(float): solar altitude in radians.
         radiation_sum(float): diffuse radiation + beam radiation.
+        return_converged(bool): if True, output contains information on whether computation converged.
+            Default is False.
+
     Returns:
-        integer or np.nan: nebulosity (integer between 0 and 8).
+        float, array[float], tuple[float, bool] or tuple[array[float], array[bool]]:
+        If return_converged is False, returns the nebulosity, as float or float array depending on the input.
+        nebulosity is an integer between 0 and 8 (or nan).
+        If return_converged is True, the output is a tuple where the first element is the nebulosity (same as above)
+        and the second element signals whether the computation converged. It is a bool or a bool array
+        depending on the input.
+
+    Examples:
+        ```python
+        >>> estimate_nebulosity_from_diffuse_and_beam_radiation(
+        >>>     np.array([1.10, -0.34]), np.array([700, 700], return_converged=False),
+        >>> )
+        array([5.0, nan])
+
+        >>> nebulosity, converged = estimate_nebulosity_from_diffuse_and_beam_radiation(
+        >>>     np.array([1.10, 1.10]), np.array([700, 10], return_converged=True),
+        >>> )
+        >>> nebulosity
+        array([5.0, 8.0])
+        >>> converged
+        array([True, False)]
+        ```
     """
 
     # Since f is strictly monotonous (increasing) we can use dichotomy
@@ -254,7 +318,7 @@ def estimate_nebulosity_from_diffuse_and_beam_radiation(
     else:
         output_shape = (1,)
 
-    nebulosity, _ = bisect_v(
+    nebulosity, error = bisect_v(
         f, lower_bound, upper_bound, output_shape, max_iterations=4
     )
 
@@ -267,7 +331,13 @@ def estimate_nebulosity_from_diffuse_and_beam_radiation(
     )
     # negative sin(solar_altitude) means this is the night
     # so can't compute nebulosity
-    return np.where(np.sin(solar_altitude) <= TOL, np.nan, nebulosity)
+    nebulosity = np.where(np.sin(solar_altitude) <= TOL, np.nan, nebulosity)
+
+    if return_converged:
+        converged = np.logical_and(error <= 1, np.logical_not(np.isnan(nebulosity)))
+        return nebulosity, converged
+
+    return nebulosity
 
 
 def compute_incidence(

--- a/test/unit/power/rte/test_power_rte_solar_heating.py
+++ b/test/unit/power/rte/test_power_rte_solar_heating.py
@@ -248,6 +248,49 @@ def test_estimate_nebulosity_from_diffuse_and_beam_radiation__scalar(
     np.testing.assert_allclose(nebulosity_estimate, expected_nebulosity)
 
 
+@pytest.mark.parametrize(
+    "diffuse_plus_beam_radiation, solar_altitude, expected_nebulosity, expected_converged",
+    [
+        (
+            700,
+            1.10,
+            5.0,
+            True,
+        ),
+        (
+            10,
+            1.10,
+            8.0,
+            False,
+        ),
+        (
+            4200,
+            1.10,
+            0.0,
+            False,
+        ),
+        (
+            700,
+            -0.34,
+            np.nan,
+            False,
+        ),
+    ],
+    ids=["nominal", "radiation too low", "radiation too high", "night"],
+)
+def test_estimate_nebulosity_from_diffuse_and_beam_radiation__scalar__return_converged(
+    diffuse_plus_beam_radiation, solar_altitude, expected_nebulosity, expected_converged
+) -> None:
+    nebulosity, converged = estimate_nebulosity_from_diffuse_and_beam_radiation(
+        solar_altitude,
+        diffuse_plus_beam_radiation,
+        return_converged=True,
+    )
+
+    np.testing.assert_equal(nebulosity, expected_nebulosity)
+    assert converged == expected_converged
+
+
 def test_estimate_nebulosity_from_diffuse_and_beam_radiation__array() -> None:
     input_nebulosity = np.array([1, 2])
     solar_altitude = np.array([np.pi / 2, 0])
@@ -264,6 +307,38 @@ def test_estimate_nebulosity_from_diffuse_and_beam_radiation__array() -> None:
     )
 
     np.testing.assert_allclose(nebulosity_estimate, expected_nebulosity)
+
+
+def test_estimate_nebulosity_from_diffuse_and_beam_radiation__array__return_converged() -> (
+    None
+):
+    diffuse_plus_beam_radiation = np.array(
+        [
+            700,  # nominal
+            10,  # radiation too low
+            4200,  # radiation too high
+            700,  # night
+        ]
+    )
+    solar_altitude = np.array([1.10, 1.10, 1.10, -0.34])
+    expected_nebulosity = np.array(
+        [
+            5.0,
+            8.0,
+            0.0,
+            np.nan,
+        ]
+    )
+    expected_converged = np.array([True, False, False, False])
+
+    nebulosity, converged = estimate_nebulosity_from_diffuse_and_beam_radiation(
+        solar_altitude,
+        diffuse_plus_beam_radiation,
+        return_converged=True,
+    )
+
+    np.testing.assert_equal(nebulosity, expected_nebulosity)
+    np.testing.assert_equal(converged, expected_converged)
 
 
 def test_estimate_nebulosity_from_diffuse_and_beam_radiation__no_solution(
@@ -292,51 +367,78 @@ def test_estimate_nebulosity_from_diffuse_and_beam_radiation__no_solution(
     assert nebulosity == 0
 
 
-def test_estimate_nebulosity__array() -> None:
+def test_estimate_nebulosity() -> None:
     diffuse_plus_beam_radiation = np.array([700, 600])
+    diffuse_plus_beam_radiation = np.array(
+        [
+            700,  # nominal
+            10,  # radiation is too low
+            4200,  # radiation is too high
+            700,  # night
+        ]
+    )
     datetime_utc = np.array(
         [
             np.datetime64("2026-06-15T12:00:00"),
             np.datetime64("2026-06-15T12:00:00"),
+            np.datetime64("2026-06-15T12:00:00"),
+            np.datetime64("2026-06-15T00:00:00"),
         ]
     )
-    latitude = np.array([45.0, 45.0])
-    longitude = np.array([20.0, 20.0])
+    latitude = np.full(4, 45.0)
+    longitude = np.full(4, 20.0)
     nebulosity = estimate_nebulosity(
         diffuse_plus_beam_radiation,
         datetime_utc,
         latitude,
         longitude,
     )
-    assert np.allclose(nebulosity, [5, 6])
+    np.testing.assert_allclose(nebulosity, [5, 8, 0, np.nan])
 
 
-def test_estimate_nebulosity__inconsistent_radiation() -> None:
-    diffuse_plus_beam_radiation = np.array([10, 4200])
-    datetime_utc = np.array([np.datetime64("2026-06-15T12:00:00")])
-    latitude = np.array([45.0])
-    longitude = np.array([20.0])
-    nebulosity = estimate_nebulosity(
+def test_estimate_nebulosity__return_converged() -> None:
+    diffuse_plus_beam_radiation = np.array(
+        [
+            700,  # nominal
+            10,  # radiation is too low
+            4200,  # radiation is too high
+            700,  # night
+        ]
+    )
+    datetime_utc = np.array(
+        [
+            np.datetime64("2026-06-15T12:00:00"),
+            np.datetime64("2026-06-15T12:00:00"),
+            np.datetime64("2026-06-15T12:00:00"),
+            np.datetime64("2026-06-15T00:00:00"),
+        ]
+    )
+    latitude = np.full(4, 45.0)
+    longitude = np.full(4, 20.0)
+    nebulosity, converged = estimate_nebulosity(
         diffuse_plus_beam_radiation,
         datetime_utc,
         latitude,
         longitude,
+        return_converged=True,
     )
-    assert np.allclose(nebulosity, [8, 0])
-
-
-def test_estimate_nebulosity__array_night() -> None:
-    diffuse_plus_beam_radiation = np.array([700])
-    datetime_utc = np.array([np.datetime64("2026-06-15T00:00:00")])
-    latitude = np.array([45.0])
-    longitude = np.array([20.0])
-    nebulosity = estimate_nebulosity(
-        diffuse_plus_beam_radiation,
-        datetime_utc,
-        latitude,
-        longitude,
+    expected_nebulosity = [
+        5.0,
+        8.0,
+        0.0,
+        np.nan,
+    ]
+    expected_converged = np.array(
+        [
+            True,
+            False,
+            False,
+            False,
+        ]
     )
-    assert np.isnan(nebulosity[0])
+
+    np.testing.assert_equal(nebulosity, expected_nebulosity)
+    np.testing.assert_equal(converged, expected_converged)
 
 
 def test_solar_irradiance() -> None:


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
This PR adds an optional argument named `return_converged` to `estimate_nebulosity` and `estimate_nebulosity_from_diffuse_and_beam_radiation`. If not provided or set to False, it does *not* change the behavior. If set to True, the functions return booleans signaling whether the computations converged, alongside with the results. See docstrings for examples.

This feature is needed for mechaphlowers.


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No